### PR TITLE
Add flag TimerFlags.Repeat to stop-on-idle timer

### DIFF
--- a/src/K4-GOTV-Discord.cs
+++ b/src/K4-GOTV-Discord.cs
@@ -2,6 +2,7 @@
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Core.Attributes;
+using CounterStrikeSharp.API.Modules.Timers;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using FluentFTP;
@@ -260,7 +261,7 @@ namespace K4ryuuCS2GOTVDiscord
 					{
 						LastPlayerCheckTime = Server.EngineTime;
 					}
-				});
+				}, TimerFlags.REPEAT);
 			}
 
 			if (Config.AutoRecord.Enabled && hotReload)

--- a/src/K4-GOTV-Discord.cs
+++ b/src/K4-GOTV-Discord.cs
@@ -248,7 +248,7 @@ namespace K4ryuuCS2GOTVDiscord
 					if (DemoStartTime == 0.0)
 						return;
 
-					if (GetPlayerCount() <= Config.AutoRecord.IdlePlayerCountThreshold)
+					if (GetPlayerCount() < Config.AutoRecord.IdlePlayerCountThreshold)
 					{
 						double idleTime = Server.EngineTime - LastPlayerCheckTime;
 						if (idleTime > Config.AutoRecord.IdleTimeSeconds)

--- a/src/K4-GOTV-Discord.cs
+++ b/src/K4-GOTV-Discord.cs
@@ -248,7 +248,7 @@ namespace K4ryuuCS2GOTVDiscord
 					if (DemoStartTime == 0.0)
 						return;
 
-					if (GetPlayerCount() < Config.AutoRecord.IdlePlayerCountThreshold)
+					if (GetPlayerCount() <= Config.AutoRecord.IdlePlayerCountThreshold)
 					{
 						double idleTime = Server.EngineTime - LastPlayerCheckTime;
 						if (idleTime > Config.AutoRecord.IdleTimeSeconds)


### PR DESCRIPTION
`stop-on-idle` was not working when set to true. By looking at the code it seemed caused due to the timer that was supposed to stop recording on idle only running once.